### PR TITLE
Add Mocha testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Fiattib.com
+
+## Running Tests
+
+After installing dependencies, run:
+
+```bash
+npm test
+```

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ app.get("/", (req, res) => {
   res.send("Fiattib backend is live!");
 });
 
-const PORT = process.env.PORT || 8080;
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-});
+if (require.main === module) {
+  const PORT = process.env.PORT || 8080;
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "mocha"
   },
   "dependencies": {
     "express": "^4.18.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.0.0",
+    "supertest": "^6.3.3"
   },
   "engines": {
     "node": "18.x"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,11 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /', function () {
+  it('responds with Fiattib backend is live!', function (done) {
+    request(app)
+      .get('/')
+      .expect(200)
+      .expect('Fiattib backend is live!', done);
+  });
+});


### PR DESCRIPTION
## Summary
- expose Express app from `index.js`
- add Mocha & Supertest for testing
- create `test/index.test.js`
- document test command in `README`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ace1cd48332911407b48ddf72e0